### PR TITLE
Check the input type for both sign and verify. This avoids the issue whe...

### DIFF
--- a/pyelliptic/ecc.py
+++ b/pyelliptic/ecc.py
@@ -303,6 +303,9 @@ class ECC:
         """
         Sign the input with ECDSA method and returns the signature
         """
+        if not isinstance(inputb, (str, unicode)):
+            raise TypeError(inputb)
+
         try:
             size = len(inputb)
             buff = OpenSSL.malloc(inputb, size)
@@ -363,6 +366,11 @@ class ECC:
         Verify the signature with the input and the local public key.
         Returns a boolean
         """
+        if not isinstance(sig, (str, unicode)):
+            raise TypeError(sig)
+        if not isinstance(inputb, (str, unicode)):
+            raise TypeError(inputb)
+
         try:
             bsig = OpenSSL.malloc(sig, len(sig))
             binputb = OpenSSL.malloc(inputb, len(inputb))


### PR DESCRIPTION
...re something invalid is passed, OpenSSL.malloc fails and we end up with UnboundLocalError.
