### PR TITLE
Interoperable public keys

### DIFF
--- a/pyelliptic/ecc.py
+++ b/pyelliptic/ecc.py
@@ -81,6 +81,8 @@ class ECC:
             self._set_keys(pubkey_x, pubkey_y, raw_privkey)
         elif pubkey is not None:
             pubkey_x, pubkey_y = ECC._decode_pubkey(pubkey)
+            if privkey is not None:
+                raw_privkey = ECC._decode_privkey(privkey)
             self._set_keys(pubkey_x, pubkey_y, raw_privkey)
         else:
             self.privkey, self.pubkey_x, self.pubkey_y, self.selfkey = self._generate()

--- a/pyelliptic/ecc.py
+++ b/pyelliptic/ecc.py
@@ -85,7 +85,7 @@ class ECC:
                 raw_privkey = ECC._decode_privkey(privkey)
             self._set_keys(pubkey_x, pubkey_y, raw_privkey)
         else:
-            self.privkey, self.pubkey_x, self.pubkey_y, self.selfkey = self._generate()
+            self.privkey, self.pubkey_x, self.pubkey_y = self._generate()
 
     def _set_keys(self, pubkey_x, pubkey_y, privkey):
         if self.raw_check_key(privkey, pubkey_x, pubkey_y) < 0:
@@ -204,7 +204,7 @@ class ECC:
 
             self.raw_check_key(privkey, pubkeyx, pubkeyy)
 
-            return privkey, pubkeyx, pubkeyy, key
+            return privkey, pubkeyx, pubkeyy
 
         finally:
             OpenSSL.EC_KEY_free(key)

--- a/pyelliptic/openssl.py
+++ b/pyelliptic/openssl.py
@@ -71,6 +71,14 @@ class _OpenSSL:
         self.byref = ctypes.byref
         self.create_string_buffer = ctypes.create_string_buffer
 
+        self.ERR_error_string = self._lib.ERR_error_string
+        self.ERR_error_string.restype = ctypes.c_char_p
+        self.ERR_error_string.argtypes = [ctypes.c_ulong, ctypes.c_char_p]
+
+        self.ERR_get_error = self._lib.ERR_get_error
+        self.ERR_get_error.restype = ctypes.c_ulong
+        self.ERR_get_error.argtypes = []
+
         self.BN_new = self._lib.BN_new
         self.BN_new.restype = ctypes.c_void_p
         self.BN_new.argtypes = []
@@ -91,6 +99,10 @@ class _OpenSSL:
         self.BN_bin2bn.restype = ctypes.c_void_p
         self.BN_bin2bn.argtypes = [ctypes.c_void_p, ctypes.c_int,
                                    ctypes.c_void_p]
+
+        self.EC_GROUP_get_degree = self._lib.EC_GROUP_get_degree
+        self.EC_GROUP_get_degree.restype = ctypes.c_int
+        self.EC_GROUP_get_degree.argtypes = [ctypes.c_void_p]
 
         self.EC_KEY_free = self._lib.EC_KEY_free
         self.EC_KEY_free.restype = None
@@ -503,6 +515,9 @@ class _OpenSSL:
         else:
             buffer = self.create_string_buffer(size)
         return buffer
+
+    def get_error(self):
+        return OpenSSL.ERR_error_string(OpenSSL.ERR_get_error(), None)
 
 libname = ctypes.util.find_library('crypto')
 if libname is None:

--- a/test.py
+++ b/test.py
@@ -103,7 +103,7 @@ class TestICIES(unittest.TestCase):
         print("\nTEST: ECIES")
         alice = ECC()
         plaintext = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        ciphertext = ECC.encrypt(plaintext, alice.get_pubkey())
+        ciphertext = alice.encrypt(plaintext, alice.get_pubkey())
         print(hexlify(ciphertext))
         self.assertEqual(plaintext, alice.decrypt(ciphertext))
 
@@ -111,7 +111,7 @@ class TestICIES(unittest.TestCase):
         print("\nTEST: ECIES/RC4")
         alice = ECC()
         plaintext = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        ciphertext = ECC.encrypt(plaintext, alice.get_pubkey(),
+        ciphertext = alice.encrypt(plaintext, alice.get_pubkey(),
                                  ciphername="rc4")
         print(hexlify(ciphertext))
         self.assertEqual(plaintext, alice.decrypt(ciphertext, ciphername="rc4"))


### PR DESCRIPTION
The public and private keys are now stored in a more standard way (only uncompressed supported).

In the way I added some more candies:

- Support for 'hex' and 'binary' public keys input and output
- Added OpenSSL.get_error to get the underlying OpenSSL error string

I tested the interoperability with node.crypto and other javascript browser library jsbn.

The only change that breaks the current API is that ECC.crypt is no longer a static method, although the data generated with previous versions is incompatible with these changes.