### PR TITLE
Proposition of a keypair calculation method

### DIFF
--- a/pyelliptic/ecc.py
+++ b/pyelliptic/ecc.py
@@ -156,6 +156,15 @@ class ECC:
             pubkeyx = pubkeyx.raw
             OpenSSL.BN_bn2bin(pub_key_y, pubkeyy)
             pubkeyy = pubkeyy.raw
+            
+            # Adjust pubkeyx and pubkeyx size
+            field_size = OpenSSL.EC_GROUP_get_degree(ec_group)
+            secret_len = int((field_size + 7) / 8)
+
+            if len(pubkeyx) < secret_len:
+                pubkeyx = pubkeyx.rjust(secret_len, b'\0')
+            if len(pubkeyy) < secret_len:
+                pubkeyy = pubkeyy.rjust(secret_len, b'\0')
 
             return pubkeyx, pubkeyy, privkey
 

--- a/pyelliptic/hash.py
+++ b/pyelliptic/hash.py
@@ -88,7 +88,11 @@ def pbkdf2(password, salt=None, i=10000, keylen=64):
     p_password = OpenSSL.malloc(password, len(password))
     p_salt = OpenSSL.malloc(salt, len(salt))
     output = OpenSSL.malloc(0, keylen)
-    OpenSSL.PKCS5_PBKDF2_HMAC(p_password, len(password), p_salt,
-                              len(p_salt), i, OpenSSL.EVP_sha256(),
-                              keylen, output)
+    try:
+        OpenSSL.PKCS5_PBKDF2_HMAC(p_password, len(password), p_salt,
+                                  len(p_salt), i, OpenSSL.EVP_sha256(),
+                                  keylen, output)
+    except AttributeError:
+        OpenSSL.PKCS5_PBKDF2_HMAC_SHA1(p_password, len(password), p_salt,
+                                       len(p_salt), i, keylen, output)
     return salt, output.raw

--- a/pyelliptic/hash.py
+++ b/pyelliptic/hash.py
@@ -82,17 +82,17 @@ def hmac_sha512(k, m):
     return md.raw
 
 
-def pbkdf2(password, salt=None, i=10000, keylen=64):
+def pbkdf2(password, salt=None, i=10000, keylen=64, hfunc='SHA256'):
     if salt is None:
         salt = OpenSSL.rand(8)
     p_password = OpenSSL.malloc(password, len(password))
     p_salt = OpenSSL.malloc(salt, len(salt))
     output = OpenSSL.malloc(0, keylen)
-    try:
+    if hfunc == 'SHA256':
         OpenSSL.PKCS5_PBKDF2_HMAC(p_password, len(password), p_salt,
                                   len(p_salt), i, OpenSSL.EVP_sha256(),
                                   keylen, output)
-    except AttributeError:
+    else:
         OpenSSL.PKCS5_PBKDF2_HMAC_SHA1(p_password, len(password), p_salt,
                                        len(p_salt), i, keylen, output)
     return salt, output.raw

--- a/pyelliptic/openssl.py
+++ b/pyelliptic/openssl.py
@@ -373,14 +373,19 @@ class _OpenSSL:
 
         try:
             self.PKCS5_PBKDF2_HMAC = self._lib.PKCS5_PBKDF2_HMAC
-        except:
+            self.PKCS5_PBKDF2_HMAC.restype = ctypes.c_int
+            self.PKCS5_PBKDF2_HMAC.argtypes = [ctypes.c_void_p, ctypes.c_int,
+                                               ctypes.c_void_p, ctypes.c_int,
+                                               ctypes.c_int, ctypes.c_void_p,
+                                               ctypes.c_int, ctypes.c_void_p]
+        except AttributeError:
             # The above is not compatible with all versions of OSX.
-            self.PKCS5_PBKDF2_HMAC = self._lib.PKCS5_PBKDF2_HMAC_SHA1
-        self.PKCS5_PBKDF2_HMAC.restype = ctypes.c_int
-        self.PKCS5_PBKDF2_HMAC.argtypes = [ctypes.c_void_p, ctypes.c_int,
-                                           ctypes.c_void_p, ctypes.c_int,
-                                           ctypes.c_int, ctypes.c_void_p,
-                                           ctypes.c_int, ctypes.c_void_p]
+            self.PKCS5_PBKDF2_HMAC_SHA1 = self._lib.PKCS5_PBKDF2_HMAC_SHA1
+            self.PKCS5_PBKDF2_HMAC_SHA1.restype = ctypes.c_int
+            self.PKCS5_PBKDF2_HMAC_SHA1.argtypes = [ctypes.c_void_p, ctypes.c_int,
+                                                    ctypes.c_void_p, ctypes.c_int,
+                                                    ctypes.c_int, ctypes.c_int,
+                                                    ctypes.c_void_p]
 
         self._set_ciphers()
         self._set_curves()
@@ -530,7 +535,7 @@ class _OpenSSL:
         return buffer
 
     def get_error(self):
-        return OpenSSL.ERR_error_string(OpenSSL.ERR_get_error(), None)
+        return str(OpenSSL.ERR_error_string(OpenSSL.ERR_get_error(), None))
 
 libname = ctypes.util.find_library('crypto')
 if libname is None:

--- a/pyelliptic/openssl.py
+++ b/pyelliptic/openssl.py
@@ -371,21 +371,20 @@ class _OpenSSL:
                               ctypes.c_void_p, ctypes.c_int,
                               ctypes.c_void_p, ctypes.c_void_p]
 
-        try:
-            self.PKCS5_PBKDF2_HMAC = self._lib.PKCS5_PBKDF2_HMAC
-            self.PKCS5_PBKDF2_HMAC.restype = ctypes.c_int
-            self.PKCS5_PBKDF2_HMAC.argtypes = [ctypes.c_void_p, ctypes.c_int,
-                                               ctypes.c_void_p, ctypes.c_int,
-                                               ctypes.c_int, ctypes.c_void_p,
-                                               ctypes.c_int, ctypes.c_void_p]
-        except AttributeError:
-            # The above is not compatible with all versions of OSX.
-            self.PKCS5_PBKDF2_HMAC_SHA1 = self._lib.PKCS5_PBKDF2_HMAC_SHA1
-            self.PKCS5_PBKDF2_HMAC_SHA1.restype = ctypes.c_int
-            self.PKCS5_PBKDF2_HMAC_SHA1.argtypes = [ctypes.c_void_p, ctypes.c_int,
-                                                    ctypes.c_void_p, ctypes.c_int,
-                                                    ctypes.c_int, ctypes.c_int,
-                                                    ctypes.c_void_p]
+        self.PKCS5_PBKDF2_HMAC = self._lib.PKCS5_PBKDF2_HMAC
+        self.PKCS5_PBKDF2_HMAC.restype = ctypes.c_int
+        self.PKCS5_PBKDF2_HMAC.argtypes = [ctypes.c_void_p, ctypes.c_int,
+                                           ctypes.c_void_p, ctypes.c_int,
+                                           ctypes.c_int, ctypes.c_void_p,
+                                           ctypes.c_int, ctypes.c_void_p]
+
+        # The above is not compatible with all versions of OSX.
+        self.PKCS5_PBKDF2_HMAC_SHA1 = self._lib.PKCS5_PBKDF2_HMAC_SHA1
+        self.PKCS5_PBKDF2_HMAC_SHA1.restype = ctypes.c_int
+        self.PKCS5_PBKDF2_HMAC_SHA1.argtypes = [ctypes.c_void_p, ctypes.c_int,
+                                                ctypes.c_void_p, ctypes.c_int,
+                                                ctypes.c_int, ctypes.c_int,
+                                                ctypes.c_void_p]
 
         self._set_ciphers()
         self._set_curves()

--- a/pyelliptic/openssl.py
+++ b/pyelliptic/openssl.py
@@ -104,9 +104,9 @@ class _OpenSSL:
         self.BN_cmp.restype = ctypes.c_int
         self.BN_cmp.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 
-        self.BN_mask_bits = self._lib.BN_mask_bits
-        self.BN_mask_bits.restype = ctypes.c_int
-        self.BN_mask_bits.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        self.BN_rshift = self._lib.BN_rshift
+        self.BN_rshift.restype = ctypes.c_int
+        self.BN_rshift.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
 
         self.EC_GROUP_get_order = self._lib.EC_GROUP_get_order
         self.EC_GROUP_get_order.restype = ctypes.c_int

--- a/pyelliptic/openssl.py
+++ b/pyelliptic/openssl.py
@@ -100,6 +100,19 @@ class _OpenSSL:
         self.BN_bin2bn.argtypes = [ctypes.c_void_p, ctypes.c_int,
                                    ctypes.c_void_p]
 
+        self.BN_cmp = self._lib.BN_cmp
+        self.BN_cmp.restype = ctypes.c_int
+        self.BN_cmp.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+        self.BN_mask_bits = self._lib.BN_mask_bits
+        self.BN_mask_bits.restype = ctypes.c_int
+        self.BN_mask_bits.argtypes = [ctypes.c_void_p, ctypes.c_int]
+
+        self.EC_GROUP_get_order = self._lib.EC_GROUP_get_order
+        self.EC_GROUP_get_order.restype = ctypes.c_int
+        self.EC_GROUP_get_order.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                            ctypes.c_void_p]
+
         self.EC_GROUP_get_degree = self._lib.EC_GROUP_get_degree
         self.EC_GROUP_get_degree.restype = ctypes.c_int
         self.EC_GROUP_get_degree.argtypes = [ctypes.c_void_p]

--- a/pyelliptic/openssl.py
+++ b/pyelliptic/openssl.py
@@ -371,12 +371,15 @@ class _OpenSSL:
                               ctypes.c_void_p, ctypes.c_int,
                               ctypes.c_void_p, ctypes.c_void_p]
 
-        self.PKCS5_PBKDF2_HMAC = self._lib.PKCS5_PBKDF2_HMAC
-        self.PKCS5_PBKDF2_HMAC.restype = ctypes.c_int
-        self.PKCS5_PBKDF2_HMAC.argtypes = [ctypes.c_void_p, ctypes.c_int,
-                                           ctypes.c_void_p, ctypes.c_int,
-                                           ctypes.c_int, ctypes.c_void_p,
-                                           ctypes.c_int, ctypes.c_void_p]
+        try:
+            self.PKCS5_PBKDF2_HMAC = self._lib.PKCS5_PBKDF2_HMAC
+            self.PKCS5_PBKDF2_HMAC.restype = ctypes.c_int
+            self.PKCS5_PBKDF2_HMAC.argtypes = [ctypes.c_void_p, ctypes.c_int,
+                                               ctypes.c_void_p, ctypes.c_int,
+                                               ctypes.c_int, ctypes.c_void_p,
+                                               ctypes.c_int, ctypes.c_void_p]
+        except AttributeError:
+            pass
 
         # The above is not compatible with all versions of OSX.
         self.PKCS5_PBKDF2_HMAC_SHA1 = self._lib.PKCS5_PBKDF2_HMAC_SHA1

--- a/test.py
+++ b/test.py
@@ -176,6 +176,20 @@ class TestCompatibilities(unittest.TestCase):
         self.assertEqual(alice2.get_pubkey(), alice.get_pubkey())
         self.assertEqual(alice2.get_privkey(), alice.get_privkey())
 
+class TestComputeKeyPair(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_compute_key_pair(self):
+        print("\nTEST: Compute keypair")
+        secret = b"This is a secret key for testing"
+        goodx = "6e9e41bec214a5537cc4a9469485022e01f79952aa0c5dee3144e457123c05cd"
+        goody = "a6c3f0695e9092c9b688733d3302545d887c3e08906127bf70cd9434a0d529b9"
+        pubkeyx, pubkeyy, privkey = ECC.compute_keypair(secret, curve='secp256k1')
+        print(hexlify(pubkeyx))
+        print(hexlify(pubkeyy))
+        self.assertEqual(goodx, hexlify(pubkeyx))
+        self.assertEqual(goodx, hexlify(pubkeyy))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi,

I propose a method to compute a public key from a given secret and a chosen curve.

The method takes account of the order of the curve used. If the given secret is > order of the curve, the secret is truncated. The method returns raw values: pubkey_x, pubkey_y and priv_key. The private key returned can be different of the secret given if it's to big according to the order of the curve chosen. It 
can be changed (for example by raising an exception).

The method calls also OpenSSL.EC_KEY_check_key(...) to verify the key pair.

It's a proposition to discuss. I'm not an expert in cryptology.

Thierry Lemeunier
